### PR TITLE
fix responsive blockquote

### DIFF
--- a/assets/sass/main.sass
+++ b/assets/sass/main.sass
@@ -1389,7 +1389,7 @@
             blockquote
                 -moz-box-sizing: border-box
                 box-sizing: border-box
-                margin: 16px -64px 32px -64px
+                margin: 0px
                 padding: 0
                 text-align: center
                 font-size: 35.2px


### PR DESCRIPTION
Blockquotes seem to run off the screen, while also widening the viewport.  This fixes that.
## Before

_(notice the dark gray to the right, representing the wide viewport, enabling horizontal scroll)_

![2014-02-20 at 10 01 pm](https://f.cloud.github.com/assets/401520/2227014/390f136a-9ab5-11e3-87e6-1bc18d6ccba8.png)
## After

![2014-02-20 at 9 59 pm](https://f.cloud.github.com/assets/401520/2227008/09630cde-9ab5-11e3-8484-01a175d8c1c2.png)
