### PR TITLE
Change the style and script paths from absolute to use use the asset helper

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -14,15 +14,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     {{! Styles'n'Scripts }}
-    <link rel="stylesheet" type="text/css" href="/assets/css/normalize.css" />
-    <link rel="stylesheet" type="text/css" media="only screen and (max-width: 1000px)" href="/assets/css/main-mobile.css" />
-    <link rel="stylesheet" type="text/css" media="only screen and (min-width: 1001px)" href="/assets/css/main-desktop.css" />
+    <link rel="stylesheet" type="text/css" href="{{asset "assets/css/normalize.css"}}" />
+    <link rel="stylesheet" type="text/css" media="only screen and (max-width: 1000px)" href="{{asset "assets/css/main-mobile.css" }}" />
+    <link rel="stylesheet" type="text/css" media="only screen and (min-width: 1001px)" href="{{asset "assets/css/main-desktop.css"}}" />
 
     <link href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet">
-    <link href='http://fonts.googleapis.com/css?family=Lato:300,400,700,900' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=PT+Serif&subset=latin,latin-ext,cyrillic,cyrillic-ext' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Lato:300,400,700,900' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=PT+Serif&amp;subset=latin,latin-ext,cyrillic,cyrillic-ext' rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?subset=latin,cyrillic-ext,latin-ext,cyrillic&family=Droid+Serif:400,700,400italic|Open+Sans:700,400" />
+    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?subset=latin,cyrillic-ext,latin-ext,cyrillic&amp;family=Droid+Serif:400,700,400italic|Open+Sans:700,400" />
 
     {{! Ghost outputs important style and meta data with this tag }}
     {{ghost_head}}
@@ -36,7 +36,7 @@
     {{ghost_foot}}
 
     {{! The main JavaScript file for Casper }}
-    <script type="text/javascript" src="/assets/js/index.js"></script>
+    <script type="text/javascript" src="{{asset "js/index.js"}}"></script>
 
 </body>
 </html>


### PR DESCRIPTION
- Updated styles and scripts on layout to use asset helper.  This will allow the theme to work if the blog root is in a subdirectory.  i.e. http://my-ghost-blog.com/subfolder/
- Made external resources load over same protocol

Example...

```
<link rel="stylesheet" type="text/css" href="{{asset "assets/css/normalize.css"}}" />
<script type="text/javascript" src="{{asset "js/index.js"}}"></script>
```
